### PR TITLE
Fixup `dataclass` usage in nt params

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -6,9 +6,6 @@ check_untyped_defs = True
 warn_unreachable = True
 plugins = numpy.typing.mypy_plugin
 
-[mypy-dataclass.*]
-ignore_missing_imports = True
-
 [mypy-invoke.*]
 ignore_missing_imports = True
 

--- a/pm_icecon/nt/params/amsr2.py
+++ b/pm_icecon/nt/params/amsr2.py
@@ -1,7 +1,8 @@
 """Parameters for use with AMSR2 (AU_SI{12|25}) data."""
+from dataclasses import dataclass
+
 import numpy as np
 import numpy.typing as npt
-from dataclass import dataclass
 from loguru import logger
 
 from pm_icecon._types import Hemisphere
@@ -62,10 +63,8 @@ def get_amsr2_params(
     )
 
     return NasateamParams(
-        **dict(
-            shoremap=nt_shoremap,
-            minic=nt_minic,
-            tiepoints=nt_tiepoints,
-            gradient_thresholds=nt_gradient_thresholds,
-        )
+        shoremap=nt_shoremap,
+        minic=nt_minic,
+        tiepoints=nt_tiepoints,
+        gradient_thresholds=nt_gradient_thresholds,
     )


### PR DESCRIPTION
Very confused as to how this mistake made it through....