### PR TITLE
Update comparison code related to change in `pm_tb_data`

### DIFF
--- a/pm_icecon/compare/ref_data.py
+++ b/pm_icecon/compare/ref_data.py
@@ -117,12 +117,10 @@ def get_au_si_bt_conc(
     hemisphere: Hemisphere,
     resolution: au_si.AU_SI_RESOLUTIONS,
 ) -> xr.DataArray:
-    ds = au_si._get_au_si_data_fields(
-        # TODO: DRY out base dir defualt. No need to pass this around...
-        base_dir=Path(f'/ecs/DP1/AMSA/AU_SI{resolution}.001/'),
+    ds = au_si.get_au_si_tbs(
         date=date,
         hemisphere=hemisphere,
-        resolution=resolution,  # type: ignore[arg-type]
+        resolution=resolution,
     )
 
     # flip the image to be 'right-side' up


### PR DESCRIPTION
Small tweak to the comparison code to support changes being made in `pm_tb_data`.

To think about: should we keep this visualization code around? Remove it? Most of this was crafted for stakeholder meetings to show progress. 

Some code to visualize PM data, sea ice concentration data w/ and w/o flags, etc. would be nice to have. Maybe we can keep some of this code in the `pm_tb_data` or `seaice_ecdr` package? Or a separate repo?