### PR TITLE
Handle lineslopecheck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
   that define e.g., valid ice masks. This code was very specific to NSIDC's
   internal infrastructure and unpublished data. It is now the responsibility of
   other programs utlizing this library to provide masks, input TBs, etc.
+* Replace `BootstrapAlgError` in `get_linfit` with a logged warning. Use default
+  slope and offset values instead of failing when there are less than 125 valid
+  pixels.
 
 # v0.2.0
 

--- a/pm_icecon/bt/compute_bt_ic.py
+++ b/pm_icecon/bt/compute_bt_ic.py
@@ -231,7 +231,7 @@ def get_linfit(
         bt_error_message = f"""
         Insufficient valid linfit points: {num_valid_pixels}
         """
-        print(f"Possible BootstrapAlgError: {bt_error_message}")
+        logger.warning(f"Possible BootstrapAlgError: {bt_error_message}")
 
         slopeb = lnline["slope"]
         intrca = lnline["offset"]
@@ -252,7 +252,7 @@ def get_linfit(
             ' rather than "silently" fall back on some default values. We are not'
             " sure how the default values of (`iceline`) were originally chosen."
         """
-        print(f"Possible BootstrapAlgError:{bt_error_message}")
+        logger.warning(f"Possible BootstrapAlgError:{bt_error_message}")
         slopeb = max_slope
 
     fit_off = intrca + add


### PR DESCRIPTION
This PR causes warnings instead of errors to be issued when there are insufficient numbers of values for the bootstrap line-fitting routine