### PR TITLE
Adjust typing for nt param functions expecting a `ValidSatellite`.

### DIFF
--- a/pm_icecon/nt/params/nsidc0001.py
+++ b/pm_icecon/nt/params/nsidc0001.py
@@ -15,7 +15,7 @@ from pm_icecon.nt.params.amsr2 import NasateamParams
 def get_0001_nt_params(
     *,
     hemisphere: Hemisphere,
-    platform: ValidSatellites,
+    platform: ValidSatellites | str,
 ) -> NasateamParams:
     nt_tiepoints = get_tiepoints(satellite=platform, hemisphere=hemisphere)
 

--- a/pm_icecon/nt/tiepoints.py
+++ b/pm_icecon/nt/tiepoints.py
@@ -217,7 +217,7 @@ TIEPOINTS: dict[str, dict[str, NasateamTiePoints]] = {
 
 def get_tiepoints(
     *,
-    satellite: ValidSatellites,
+    satellite: ValidSatellites | str,
     hemisphere: Hemisphere,
 ) -> NasateamTiePoints:
     """Given a satellite and hemisphere, return pre-defined tiepoints."""


### PR DESCRIPTION
Associated `seaice_ecdr` PR: https://github.com/nsidc/seaice_ecdr/pull/81