### PR TITLE
Add and use 0802 nt tiepoints for AMSR2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# v0.8.0
+
+* Update `nt.tiepoints.get_tiepoints` function to return NT tiepoints based on
+  NSIDC-0802/0803 when `am2` is passed as the `satellite`. This changes the
+  previous behavior, which would return tiepoints based on AMSRU. This change
+  was made to support `seaice_ecdr` v2, which uses NSIDC-0802 TBs instead of
+  AU_SI25 for AMSR2 data.
+
 # v0.7.0
 
 * Update dependencies for `pm_tb_data`

--- a/pm_icecon/nt/tiepoints.py
+++ b/pm_icecon/nt/tiepoints.py
@@ -186,6 +186,19 @@ TIEPOINTS: dict[str, dict[str, NasateamTiePoints]] = {
             "37v": {"ow": 211.90, "fy": 249.25, "my": 217.10},
         },
     },
+    # Source: params used in NSIDC0803
+    "nsidc0803": {
+        "n": {
+            "19h": {"ow": 120.50, "fy": 235.50, "my": 200.70},
+            "19v": {"ow": 185.9, "fy": 250.90, "my": 222.20},
+            "37v": {"ow": 210.50, "fy": 241.30, "my": 188.60},
+        },
+        "s": {
+            "19h": {"ow": 118.20, "fy": 240.90, "my": 214.60},
+            "19v": {"ow": 192.40, "fy": 256.40, "my": 246.70},
+            "37v": {"ow": 208.70, "fy": 246.20, "my": 212.40},
+        },
+    },
     # Source: cdralgos
     "n07": {
         "n": {
@@ -245,7 +258,8 @@ def get_tiepoints(
             # TODO: we should calculate specific tiepoints for AMSRE (`ame`)
             # instead of using the AMSR2 tiepoints.
             "ame": "amsru_a2",
-            "am2": "amsru_a2",
+            "am2": "nsidc0803",
+            # "am2": "amsru_a2",
             "u2": "amsru_a2",
             "17_final": "f17_final",
             "18_class": "f18_class",

--- a/pm_icecon/nt/tiepoints.py
+++ b/pm_icecon/nt/tiepoints.py
@@ -252,14 +252,25 @@ def get_tiepoints(
     satellite: ValidSatellites | str,
     hemisphere: Hemisphere,
 ) -> NasateamTiePoints:
-    """Given a satellite and hemisphere, return pre-defined tiepoints."""
+    """Given a satellite and hemisphere, return pre-defined tiepoints.
+
+    NOTE/TODO: this function is specifically designed to return tiepoints for
+    data sources utilized by the latest version of the `seaice_ecdr`. E.g.,
+    passing `am2` as the `satellite` will return tiepoints based on NSIDC-0802
+    for use in NSIDC-0803, which is what we want for the `seaice_ecdr`. The
+    `amsru_am2` "satellite" will return tiepoints derived from AMSRU
+    data. Ideally, this function is updated to replace the `satellite` kwarg
+    with e.g., `platform` and `product` kwargs. The combination of `platform`
+    and `product` tells us which variant of a set of tiepoints should be
+    returned, instead of curating the dict below.
+    """
     try:
         sat = {
             # TODO: we should calculate specific tiepoints for AMSRE (`ame`)
             # instead of using the AMSR2 tiepoints.
             "ame": "amsru_a2",
             "am2": "nsidc0803",
-            # "am2": "amsru_a2",
+            "amsru_am2": "amsru_a2",
             "u2": "amsru_a2",
             "17_final": "f17_final",
             "18_class": "f18_class",

--- a/pm_icecon/nt/tiepoints.py
+++ b/pm_icecon/nt/tiepoints.py
@@ -186,8 +186,8 @@ TIEPOINTS: dict[str, dict[str, NasateamTiePoints]] = {
             "37v": {"ow": 211.90, "fy": 249.25, "my": 217.10},
         },
     },
-    # Source: params used in NSIDC0803
-    "nsidc0803": {
+    # Source: params derived from NSIDC0802 and used in NSIDC0803
+    "nsidc0802": {
         "n": {
             "19h": {"ow": 120.50, "fy": 235.50, "my": 200.70},
             "19v": {"ow": 185.9, "fy": 250.90, "my": 222.20},
@@ -269,7 +269,7 @@ def get_tiepoints(
             # TODO: we should calculate specific tiepoints for AMSRE (`ame`)
             # instead of using the AMSR2 tiepoints.
             "ame": "amsru_a2",
-            "am2": "nsidc0803",
+            "am2": "nsidc0802",
             "amsru_am2": "amsru_a2",
             "u2": "amsru_a2",
             "17_final": "f17_final",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pm_icecon"
-version = "0.7.0"
+version = "0.8.0"
 description = "Sea ice concentration estimates from passive microwave data"
 
 [tool.setuptools]
@@ -45,7 +45,7 @@ max-complexity = 8
 inline-quotes = "double"
 
 [tool.bumpversion]
-current_version = "0.7.0"
+current_version = "0.8.0"
 commit = false
 tag = false
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: pm_icecon
-  version: "0.7.0"
+  version: "0.8.0"
 
 source:
   path: ../


### PR DESCRIPTION
Add NT tiepoints for use with NSIDC0802 and make that tiepoint set the default when `am2` is passed as `satellite` to `nt.tiepoints.get_tiepoints`. 

Data were provided by @sc0tts:

```
c     data ARRAY  
c                   N-AS2, S-AS2  / # AMSR2 L1R base data
      data TB19VW /
     $     185.9, 192.4         ! N-AS2, S-AS2

      data TB19VF /
     $     250.9, 256.4     ! N-AS2, S-AS2

      data TB19VM /
     $     222.2, 246.7     ! N-AS2, S-AS2

      data TB19HW /
     $     120.5, 118.2     ! N-AS2, S-AS2

      data TB19HF /
     $     235.5, 240.9     ! N-AS2, S-AS2

      data TB19HM /
     $     200.7, 214.6     ! N-AS2, S-AS2

      data TB37VW /
     $     210.5, 208.7     ! N-AS2, S-AS2

      data TB37VF /
     $     241.3, 246.2     ! N-AS2, S-AS2

      data TB37VM /
     $     188.6, 212.4     ! N-AS2, S-AS2
```